### PR TITLE
Update Google Analytics ID

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,4 +2,4 @@ theme: jekyll-theme-cayman
 title: IBM Application Navigator
 description: The official documentation for IBM Application Navigator, part of the IBM Cloud Pak for Applications
 show_downloads: false
-google_analytics: GTM-KSL4WLN
+google_analytics: UA-149634731-1


### PR DESCRIPTION
- Use the Google Analytics ID instead of the Google Tag Manager ID